### PR TITLE
committed-bold-label-for-navtabs-and-active-tab-in-profile-comp

### DIFF
--- a/raaghu-elements/src/rds-nav-tab/src/lib/rds-nav-tab.component.html
+++ b/raaghu-elements/src/rds-nav-tab/src/lib/rds-nav-tab.component.html
@@ -18,7 +18,7 @@
                       </div>-->
                       <!--</div>
                       <div class="col-10">-->
-                  <span class="ms-2">
+                  <span class="ms-2" [ngClass]="{'fw-bold': item.subText}">
                     {{item.label}}
                   </span>
                   <div class="text-muted fw-light ps-4 ms-2">{{item.subText}}</div>

--- a/raaghu-elements/src/rds-nav-tab/src/lib/rds-nav-tab.component.ts
+++ b/raaghu-elements/src/rds-nav-tab/src/lib/rds-nav-tab.component.ts
@@ -19,12 +19,12 @@ export class RdsNavTabComponent implements OnInit {
   @Input() iconWidth: string = '20px';
   @Output()
   onClicktab = new EventEmitter<{ evnt: any }>();
-  @Input() activepage!: number;
+  @Input() activepage: number = 0;
   @Input() tabsWithBorderTop?: boolean = true;
   constructor() { }
 
   ngOnInit(): void {
-    this.activepage = 0;
+    // this.activepage = 0;
   }
 
   onClick(i: any): void {

--- a/raaghu-mfe/projects/rds-components/src/app/rds-comp-profile/rds-comp-profile.component.html
+++ b/raaghu-mfe/projects/rds-components/src/app/rds-comp-profile/rds-comp-profile.component.html
@@ -67,7 +67,7 @@
             </div>
 
             <rds-nav-tab [navtabsItems]="getMenuItems()" horizontalAlignment="start" [verticalAlignment]="true"
-              [pills]="false" [tabs]="false" [fill]="false" [justified]="false" [flex]="false"
+              [pills]="false" [tabs]="false" [fill]="false" [justified]="false" [flex]="false" [activepage]="-1"
               (onClicktab)="onclickMenu($event)">
             </rds-nav-tab>
             <div></div>


### PR DESCRIPTION
> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.

## Description

> Added bold class for the nav tab label when sub text is available.
> Removed the by default active status for the profile component tabs.

Fixes # (issue)

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Please check the label of the nav tab whether it is bold where sub text is added.
- Please check there is no active class assigned for the navtab in profile component by default. There should be no border for the navtab in profile component by default.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
